### PR TITLE
Add several bounded Until test cases

### DIFF
--- a/functionality/verify/dtmcs/bounded-reach/bounded-reach-1.pm.props
+++ b/functionality/verify/dtmcs/bounded-reach/bounded-reach-1.pm.props
@@ -216,6 +216,113 @@ P=? [ s<3 U[3,10] true ]
 
 
 
+// test cases where the left and right operand
+// are the same
+// RESULT: 1.0
+P=? [ s<4 U[0,0] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[0,1] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[0,2] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[0,3] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[0,4] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[0,5] s<4 ]
+
+// RESULT: 1.0
+P=? [ s<4 U[0,4] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[1,4] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[2,4] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[3,4] s<4 ]
+// RESULT: 0.0
+P=? [ s<4 U[4,4] s<4 ]
+
+// RESULT: 1.0
+P=? [ s<4 U[0,5] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[1,5] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[2,5] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[3,5] s<4 ]
+// RESULT: 0.0
+P=? [ s<4 U[4,5] s<4 ]
+// RESULT: 0.0
+P=? [ s<4 U[5,5] s<4 ]
+
+// RESULT: 1.0
+P=? [ s<4 U[0,3] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[1,3] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[2,3] s<4 ]
+// RESULT: 1.0
+P=? [ s<4 U[3,3] s<4 ]
+
+
+// test cases where the left and right operand
+// are dual
+// RESULT: 0.0
+P=? [ s!=3 U[0,0] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[1,1] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[2,2] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[3,3] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[4,4] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[5,5] s=3 ]
+
+// RESULT: 0.0
+P=? [ s!=3 U[0,1] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[1,2] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[2,3] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[3,4] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[4,5] s=3 ]
+
+// RESULT: 0.0
+P=? [ s!=3 U[0,2] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[1,3] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[2,4] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[3,5] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[4,6] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[0,3] s=3 ]
+
+// RESULT: 1.0
+P=? [ s!=3 U[1,4] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[2,5] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[3,6] s=3 ]
+// RESULT: 0.0
+P=? [ s!=3 U[4,7] s=3 ]
+
+// RESULT: 1.0
+P=? [ s!=3 U[0,4] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[1,5] s=3 ]
+// RESULT: 1.0
+P=? [ s!=3 U[2,6] s=3 ]
+
+
+
+
 // ------ Bounds for Release ----------------
 // a R[l,u] b = !(!a U[l,u] !b)
 


### PR DESCRIPTION
Test cases where PRISM generates formulas of the type 'L0 U[bound] L0' and 'L0 U[bound] !L0'. When generating deterministic automata for these automata, care has to be taken because there is only one atomic proposition.
