### PR TITLE
Add missing model files for LTL fairness tests.

### DIFF
--- a/functionality/verify/mdps/ltl-fair/Bai98-ex9.4.12-p239.nm
+++ b/functionality/verify/mdps/ltl-fair/Bai98-ex9.4.12-p239.nm
@@ -1,0 +1,24 @@
+// simple LTL/fairness example from Christel's thesis (p.239-240)
+
+// note that the product MDP in fig 9.15 is incorrect:
+// s_3,q_0 should be s_3,q_1
+// s_5,q_1 should be s_5,q_2
+// (and thus state s_5,q_1 disappears)
+
+mdp
+
+module M
+
+	s : [1..5];
+
+	[] (s=1) -> (s'=2);
+	[] (s=2) -> (s'=2);
+	[] (s=2) -> 0.5:(s'=3) + 0.5:(s'=4);
+	[] (s=3) -> (s'=5);
+	[] (s=4) -> (s'=5);
+	[] (s=5) -> (s'=5);
+	
+endmodule
+
+label "a" = s=3;
+label "b" = s=2 | s=5;

--- a/functionality/verify/mdps/ltl-fair/Bai98-remark9.4.13-p240.nm
+++ b/functionality/verify/mdps/ltl-fair/Bai98-remark9.4.13-p240.nm
@@ -1,0 +1,20 @@
+// another simple LTL example from Christel's thesis (p.240)
+
+mdp
+
+module M
+
+	s : [1..3];
+	
+	// s
+	[] (s=1) -> (s'=2);
+	[] (s=1) -> (s'=3);
+	// t
+	[] (s=2) -> (s'=1);
+	// u
+	[] (s=3) -> (s'=3);
+	
+endmodule
+
+label "a" = s=1 | s=2;
+label "b" = s=2;


### PR DESCRIPTION
The model files for the mdps/ltl-fair tests were missing. Copy them from mdps/ltl.
